### PR TITLE
Adding video data type as a subtype of binary

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -3,6 +3,7 @@
   <registration converters_path="lib/galaxy/datatypes/converters" display_path="display_applications">
 
     <!-- AMP Data Types-->
+    <datatype extension="video" type="galaxy.datatypes.binary:Video" subclass="True" display_in_upload="true"/>
     <datatype extension="audio" type="galaxy.datatypes.binary:Audio" subclass="True" display_in_upload="true"/>
     <datatype extension="wav" type="galaxy.datatypes.binary:Wav" subclass="True" display_in_upload="true"/>
     <!-- END AMP Data Types-->
@@ -729,8 +730,9 @@
     defined format first, followed by next-most rigidly defined,
     and so on.
     -->
-    <sniffer type="galaxy.datatypes.binary:Wav"/>
     <sniffer type="galaxy.datatypes.binary:Audio"/>
+    <sniffer type="galaxy.datatypes.binary:Video"/>
+    <sniffer type="galaxy.datatypes.binary:Wav"/>
 
     <sniffer type="galaxy.datatypes.plant_tribes:PlantTribesKsComponents"/>
     <sniffer type="galaxy.datatypes.plant_tribes:Smat"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -58,7 +58,9 @@ class Binary(data.Data):
     def get_mime(self):
         """Returns the mime type of the datatype"""
         return 'application/octet-stream'
-
+##########################
+# AMP data types
+##########################
 class Audio(Binary):
     """Class describing a binary audio file"""
     file_ext = "audio"
@@ -80,6 +82,28 @@ class Audio(Binary):
             return dataset.peek
         except Exception:
             return "Binary audio file (%s)" % (nice_size(dataset.get_size()))
+
+class Video(Binary):
+    """Class describing a binary video file"""
+    file_ext = "video"
+
+    def sniff(self, filename):
+        mt = subprocess.check_output(['file', '--mime-type', filename])
+        return  mt.find("video/")>=0
+    
+    def set_peek(self, dataset, is_multi_byte=False):
+        if not dataset.dataset.purged:
+            dataset.peek = "Binary video file"
+            dataset.blurb = nice_size(dataset.get_size())
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        try:
+            return dataset.peek
+        except Exception:
+            return "Binary video file (%s)" % (nice_size(dataset.get_size()))
 
 class Wav(Audio):
     """Class describing a wave audio file"""
@@ -103,6 +127,9 @@ class Wav(Audio):
         except Exception:
             return "Wave audio file (%s)" % (nice_size(dataset.get_size()))
 
+##########################
+# End AMP data types
+##########################
 class Ab1(Binary):
     """Class describing an ab1 binary sequence file"""
     file_ext = "ab1"


### PR DESCRIPTION
Adds video data type as a sub-type of binary with a sniffer that looks for the mime-type "video/".  Registered in datatypes_conf.xml