### PR TITLE
Amp 395 adding segmentation data type

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -3,10 +3,12 @@
   <registration converters_path="lib/galaxy/datatypes/converters" display_path="display_applications">
 
     <!-- AMP Data Types-->
-    <datatype extension="video" type="galaxy.datatypes.binary:Video" subclass="True" display_in_upload="true"/>
-    <datatype extension="music" type="galaxy.datatypes.binary:Music" subclass="True" display_in_upload="true"/>
-    <datatype extension="audio" type="galaxy.datatypes.binary:Audio" subclass="True" display_in_upload="true"/>
-    <datatype extension="wav" type="galaxy.datatypes.binary:Wav" subclass="True" display_in_upload="true"/>
+    <datatype extension="video" type="galaxy.datatypes.binary:Video" subclass="true" display_in_upload="true"/>
+    <datatype extension="music" type="galaxy.datatypes.binary:Music" subclass="true" display_in_upload="true"/>
+    <datatype extension="speech" type="galaxy.datatypes.binary:Speech" subclass="true" display_in_upload="true"/>
+    <datatype extension="audio" type="galaxy.datatypes.binary:Audio" subclass="true" display_in_upload="true"/>
+    <datatype extension="wav" type="galaxy.datatypes.binary:Wav" subclass="true" display_in_upload="true"/>
+    <datatype extension="segments" type="galaxy.datatypes.text:Segments" subclass="true" display_in_upload="true" />
     <!-- END AMP Data Types-->
 
     <datatype extension="ab1" type="galaxy.datatypes.binary:Ab1" mimetype="application/octet-stream" display_in_upload="true" description="A binary sequence file in 'ab1' format with a '.ab1' file extension.  You must manually select this 'File Format' when uploading the file." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Ab1"/>
@@ -734,6 +736,7 @@
     <sniffer type="galaxy.datatypes.binary:Audio"/>
     <sniffer type="galaxy.datatypes.binary:Video"/>
     <sniffer type="galaxy.datatypes.binary:Wav"/>
+    <sniffer type="galaxy.datatypes.text:Segments"/>
 
     <sniffer type="galaxy.datatypes.plant_tribes:PlantTribesKsComponents"/>
     <sniffer type="galaxy.datatypes.plant_tribes:Smat"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -123,6 +123,24 @@ class Music(Binary):
         except Exception:
             return "Audio music file (%s)" % (nice_size(dataset.get_size()))
 
+class Speech(Binary):
+    """Class describing an audio speech file"""
+    file_ext = "speech"
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        if not dataset.dataset.purged:
+            dataset.peek = "Audio speech file"
+            dataset.blurb = nice_size(dataset.get_size())
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        try:
+            return dataset.peek
+        except Exception:
+            return "Audio speech file (%s)" % (nice_size(dataset.get_size()))
+
 class Wav(Audio):
     """Class describing a wave audio file"""
     file_ext = "wav"

--- a/tools/ina_speech_segmenter/ina_speech_segmenter.xml
+++ b/tools/ina_speech_segmenter/ina_speech_segmenter.xml
@@ -8,7 +8,7 @@
     <param name="input" type="data" format="audio" label="From dataset" help="An audio file"/>
   </inputs>
   <outputs>
-    <data format="json" name="json_out" />
+    <data format="segments" name="json_out" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/remove_silence_music.xml
+++ b/tools/ina_speech_segmenter/remove_silence_music.xml
@@ -7,7 +7,7 @@
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
-    <param name="input_segmentation_json" type="data" format="json" label="From segmentation" help="Segmentation json file"/>
+    <param name="input_segmentation_json" type="data" format="segments" label="From segmentation" help="Segmentation json file"/>
   </inputs>
   <outputs>
     <data format="audio" name="binary_out" />

--- a/tools/ina_speech_segmenter/remove_silence_speech.xml
+++ b/tools/ina_speech_segmenter/remove_silence_speech.xml
@@ -7,7 +7,7 @@
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
-    <param name="input_segmentation_json" type="data" format="json" label="From segmentation" help="Segmentation json file"/>
+    <param name="input_segmentation_json" type="data" format="segments" label="From segmentation" help="Segmentation json file"/>
   </inputs>
   <outputs>
     <data format="audio" name="binary_out" />


### PR DESCRIPTION
This merge request covers both AMP 394 and AMP 395.  It adds segmentation (subclass of Json) and audio/speech (subclass of Audio) data types.  The segmentation data type has a sniffer which looks for the keys "media" and "segments" in the json file.    The audio/speech data type does not have a sniffer.  The segmentation data type is used as output from the Ina Speech Segmenter, and as input to the remove music/speech tools. 