### PR TITLE
AMP-486: fix remove music/speech tools disappearing issue: can't use &

### DIFF
--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -23,9 +23,9 @@
   </section>
   <section id="Segmentation" name="Segmentation">
     <tool file="ina_speech_segmenter/ina_speech_segmenter.xml"/>
-    <tool file="amp_json_schema/adjust_timestamps.xml"/>
     <tool file="ina_speech_segmenter/remove_silence_music.xml"/>
     <tool file="ina_speech_segmenter/remove_silence_speech.xml"/>
+    <tool file="amp_json_schema/adjust_timestamps.xml"/>
   </section>
   <section id="nlp" name="Natural Language Processing">
     <tool file="spacy/spacy.xml"/>

--- a/tools/ina_speech_segmenter/remove_silence_music.xml
+++ b/tools/ina_speech_segmenter/remove_silence_music.xml
@@ -1,4 +1,4 @@
-<tool id="remove_silence_music" name="Remove Silence & Music" version="1.0.0">
+<tool id="remove_silence_music" name="Remove Silence and Music" version="1.0.0">
   <description>Create an audio file containing only speech, removing silence and music</description>
     <requirements>
     </requirements>

--- a/tools/ina_speech_segmenter/remove_silence_speech.xml
+++ b/tools/ina_speech_segmenter/remove_silence_speech.xml
@@ -1,4 +1,4 @@
-<tool id="remove_silence_speech" name="Remove Silence & Speech" version="1.0.0">
+<tool id="remove_silence_speech" name="Remove Silence and Speech" version="1.0.0">
   <description>Create an audio file containing only music, removing silence and speech</description>
     <requirements>
     </requirements>


### PR DESCRIPTION
in tool name