### PR TITLE
Amp 593 ignoring spacy groups

### DIFF
--- a/tools/ina_speech_segmenter/remove_silence_music_speech.py
+++ b/tools/ina_speech_segmenter/remove_silence_music_speech.py
@@ -104,7 +104,7 @@ def create_audio_part(input_file, start, end, segment, file_duration):
 	duration = (end_offset - start_offset)
 	duration_str = time.strftime('%H:%M:%S', time.gmtime(duration))
 
-	print("Removeing segment starting at " + start_str + " for " + duration_str)
+	print("Removing segment starting at " + start_str + " for " + duration_str)
 
 	# Execute ffmpeg command to split of the segment
 	ffmpeg_out = subprocess.Popen(['ffmpeg', '-i', input_file, '-ss', start_str, '-t', duration_str, '-acodec', 'copy', tmp_filename], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/tools/spacy/spacy.xml
+++ b/tools/spacy/spacy.xml
@@ -2,10 +2,11 @@
   <description>Named entity extraction with spaCy</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/spacy_wrapper.py $input $json_out</command>
+  <command detect_errors="exit_code">$__tool_directory__/spacy_wrapper.py $input $json_out $ignore_categories_csv</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="txt" label="From transcript" help="An transcript file"/>
+    <param name="ignore_categories_csv" type="data" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore"/>
   </inputs>
   <outputs>
     <data format="json" name="json_out" />

--- a/tools/spacy/spacy_wrapper.py
+++ b/tools/spacy/spacy_wrapper.py
@@ -19,6 +19,11 @@ from speech_to_text_schema import SpeechToText, SpeechToTextMedia, SpeechToTextR
 def main():
     (input_file, json_file) = sys.argv[1:3]
 
+    # Read a list of categories to ignore when outputting entity list
+    ignore_cats_list = list()
+    if len(sys.argv) >= 3:
+        ignore_cats_list = read_ignore_list(sys.argv[3])
+
     # Load English tokenizer, tagger, parser, NER and word vectors
     nlp = spacy.load("en_core_web_lg")
 
@@ -46,6 +51,9 @@ def main():
 
     # Find named entities, phrases and concepts - Add them to the result
     for entity in doc.ents:
+        # Ignore certain categories
+        if clean_text(entity.label_) in ignore_cats_list:
+            continue
         # Start and end time offsets
         start = None
         end = None
@@ -71,6 +79,21 @@ def main():
     
     # Write the json file
     write_json_file(result, json_file)
+
+# Standardize ignore list text
+def clean_text(text):
+    return text.lower().strip()
+
+# Read a list of categories to ignore
+def read_ignore_list(ignore_list_filename):
+    print("Reading list")
+    ignore_cats_list = list()
+    f = open(ignore_list_filename, "r")
+    # For each value in the comma separated list.  Standardize text
+    for val in f.read().split(","):
+        ignore_cats_list.append(clean_text(val))
+    print(ignore_cats_list)
+    return ignore_cats_list
 
 # Serialize obj and write it to output file
 def write_json_file(obj, output_file):


### PR DESCRIPTION
Adds a parameter to spacy entity extraction that allows users to supply a list of comma separated values to ignore when outputting entity results.  In cases where no values should be ignored, an empty file can be supplied.