### PR TITLE
Changing input param for spacy to ignore groups based on string

### DIFF
--- a/tools/aws/aws_comprehend.py
+++ b/tools/aws/aws_comprehend.py
@@ -192,8 +192,8 @@ def read_ignore_list(ignore_list_filename):
     print(ignore_cats_list)
     return ignore_cats_list
 
+# Split a comma separated string, standardize input, and return list
 def split_ignore_list(ignore_list_string):
-    print("Reading list")
     to_return = list()
     ignore_cats_list = ignore_list_string.split(',')
     for cat in ignore_cats_list:

--- a/tools/aws/aws_comprehend.xml
+++ b/tools/aws/aws_comprehend.xml
@@ -8,7 +8,7 @@
     <param name="input" type="data" format="txt" label="From transcript" help="An transcript file"/>
     <param name="bucketName" type="text" format="txt" label="S3 Bucket Name" help="An existing bucket name in AWS S3"/>
     <param name="dataAccessRoleArn" type="text" format="txt" label="IAM Data Access Role" help="An AWS IAM role providing access from AWS comprehend to S3"/>
-    <param name="ignore_categories_csv" type="text" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore">
+    <param name="ignore_categories_csv" type="text" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore.  For instance, 'QUANTITY, ORGANIZATION'.">
      <sanitizer sanitize="false">
     </sanitizer>
     </param>

--- a/tools/spacy/spacy.xml
+++ b/tools/spacy/spacy.xml
@@ -6,7 +6,10 @@
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="txt" label="From transcript" help="An transcript file"/>
-    <param name="ignore_categories_csv" type="data" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore"/>
+    <param name="ignore_categories_csv" type="text" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore.  For instance, 'QUANTITY, ORGANIZATION'.">
+     <sanitizer sanitize="false">
+    </sanitizer>
+    </param>
   </inputs>
   <outputs>
     <data format="json" name="json_out" />

--- a/tools/spacy/spacy_wrapper.py
+++ b/tools/spacy/spacy_wrapper.py
@@ -21,8 +21,9 @@ def main():
 
     # Read a list of categories to ignore when outputting entity list
     ignore_cats_list = list()
-    if len(sys.argv) >= 3:
-        ignore_cats_list = read_ignore_list(sys.argv[3])
+    if len(sys.argv) > 3:
+        print("Categories to ignore:" + sys.argv[3])
+        ignore_cats_list = split_ignore_list(sys.argv[3])
 
     # Load English tokenizer, tagger, parser, NER and word vectors
     nlp = spacy.load("en_core_web_lg")
@@ -83,6 +84,14 @@ def main():
 # Standardize ignore list text
 def clean_text(text):
     return text.lower().strip()
+
+# Split a comma separated string, standardize input, and return list
+def split_ignore_list(ignore_list_string):
+    to_return = list()
+    ignore_cats_list = ignore_list_string.split(',')
+    for cat in ignore_cats_list:
+        to_return.append(clean_text(cat))
+    return to_return
 
 # Read a list of categories to ignore
 def read_ignore_list(ignore_list_filename):


### PR DESCRIPTION
Updates this PR to use a non-sanitized string for categories to ignore, matching the comprehend PR.  Also adds a few comments and an example to the help text. 