### PR TITLE
Updating output variable names

### DIFF
--- a/tools/amp_json_schema/adjust_timestamps.xml
+++ b/tools/amp_json_schema/adjust_timestamps.xml
@@ -6,11 +6,11 @@
   <command detect_errors="exit_code">$__tool_directory__/adjust_timestamps.py $stt_json $adj_json $output_json</command>
    <inputs>
    <!-- should be wave data type -->
-    <param name="stt_json" type="data" format="json" label="From Speech to Text" help="Speech to text output"/>
-    <param name="adj_json" type="data" format="json" label="From Remove Segments" help="List of kept segments"/>
+    <param name="stt_json" type="data" format="json" label="AMP Speech to Text JSON From Speech to Text" help="Speech to text output"/>
+    <param name="adj_json" type="data" format="json" label="Kept segments JSON From Remove Segments" help="List of kept segments"/>
   </inputs>
   <outputs>
-    <data format="json" name="output_json" />
+    <data format="json" name="amp_speech_to_text" />
   </outputs>
   <tests>
   </tests>

--- a/tools/aws/aws_comprehend.xml
+++ b/tools/aws/aws_comprehend.xml
@@ -3,9 +3,9 @@
     <requirements>
         <requirement type="package" version="1.14">aws-cli</requirement>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/aws_comprehend.py $input $output_file $bucketName $dataAccessRoleArn $ignore_categories_csv</command>
+  <command detect_errors="exit_code">$__tool_directory__/aws_comprehend.py $input $amp_entity_extraction $bucketName $dataAccessRoleArn $ignore_categories_csv</command>
   <inputs>
-    <param name="input" type="data" format="txt" label="From transcript" help="An transcript file"/>
+    <param name="input" type="data" format="txt" label="AMP Speech To Text" help="An AMP transcript json file"/>
     <param name="bucketName" type="text" format="txt" label="S3 Bucket Name" help="An existing bucket name in AWS S3"/>
     <param name="dataAccessRoleArn" type="text" format="txt" label="IAM Data Access Role" help="An AWS IAM role providing access from AWS comprehend to S3"/>
     <param name="ignore_categories_csv" type="text" format="txt" label="Categories to ignore" help="Comma separated list of categories to ignore.  For instance, 'QUANTITY, ORGANIZATION'.">
@@ -14,7 +14,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="json" name="output_file" />
+    <data format="json" name="amp_entity_extraction" />
   </outputs>
   <tests>
   </tests>

--- a/tools/aws/transcribe.xml
+++ b/tools/aws/transcribe.xml
@@ -5,8 +5,8 @@
         <requirement type="package" version="1.14">aws-cli</requirement>
         <requirement type="package" version="1.5">jq</requirement>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/transcribe.sh $__root_dir__/../galaxy_logs/aws/transcribe $input_file $output_file $audio_format $s3_bucket $s3_directory;
-                                    $__tool_directory__/../amp_json_schema/aws_transcribe_to_schema.py $input_file $output_file $output_stt_json $output_seg_json
+  <command detect_errors="exit_code">$__tool_directory__/transcribe.sh $__root_dir__/../galaxy_logs/aws/transcribe $input_file $aws_transcribe_transcript $audio_format $s3_bucket $s3_directory;
+                                    $__tool_directory__/../amp_json_schema/aws_transcribe_to_schema.py $input_file $aws_transcribe_transcript $amp_speech_to_text $amp_segmentation
   </command>
   <inputs>
     <param name="input_file" type="data" format="audio" label="Input File Path" help="Audio file to transcribe"/>
@@ -28,9 +28,9 @@
     <param name="s3_directory" type="text" label="S3 Directory Path" help="S3 directory inside S3 bucket for input files"/>
   </inputs>
   <outputs>
-    <data format="json" name="output_file" />
-    <data format="json" name="output_stt_json" />
-    <data format="json" name="output_seg_json" />
+    <data format="json" name="aws_transcribe_transcript" />
+    <data format="json" name="amp_speech_to_text" />
+    <data format="json" name="amp_segmentation" />
   </outputs>
   <tests>
   </tests>

--- a/tools/hmgm/hmgm_ner.xml
+++ b/tools/hmgm/hmgm_ner.xml
@@ -1,21 +1,21 @@
 <tool id="hmgm_ner" name="HMGM NER Correction" version="1.0.0">
   <description>Manual NER correction by a human</description>
   <command detect_errors="exit_code">
-  	$__tool_directory__/../amp_json_schema/ner_to_iiif.py $input_ner $input_iiif '$context_json';
-  	$__tool_directory__/hmgm_main.py NER $__root_dir__ $input_iiif $output_iiif $task_info '$context_json';
-    $__tool_directory__/../amp_json_schema/iiif_to_ner.py $output_iiif $input_ner $output_ner
+  	$__tool_directory__/../amp_json_schema/ner_to_iiif.py $input_ner $original_iiif '$context_json';
+  	$__tool_directory__/hmgm_main.py NER $__root_dir__ $original_iiif $corrected_iiif $task_info '$context_json';
+    $__tool_directory__/../amp_json_schema/iiif_to_ner.py $corrected_iiif $input_ner $amp_entity_extraction
 </command>                                    
   <inputs>
-    <param name="input_ner" type="data" format="json" label="Input NER JSON file" help="JSON file for the NER file to be corrected "/>
+    <param name="input_ner" type="data" format="json" label="Input Entity Extraction JSON file" help="AMP JSON file for the Entity Extraction (NER) file to be corrected "/>
     <param name="context_json" type="text" label="Human MGM Task Context" help="JSON string containing context information needed for creating Human MGM task">
     	<sanitizer sanitize="false">
     	</sanitizer>
 	</param>
   </inputs>
   <outputs>
-    <data name="input_iiif" format="json" />
-    <data name="output_iiif" format="json" />
-    <data name="output_ner" format="json" />
+    <data name="original_iiif" format="json" />
+    <data name="corrected_iiif" format="json" />
+    <data name="amp_entity_extraction" format="json" />
     <data name="task_info" format="json" />
   </outputs>
   <tests>

--- a/tools/hmgm/hmgm_segmentation.xml
+++ b/tools/hmgm/hmgm_segmentation.xml
@@ -1,15 +1,15 @@
 <tool id="hmgm_segmentation" name="HMGM Segmentation Correction" version="1.0.0">
   <description>Manual segmentation correction by a human</description>
-  <command detect_errors="exit_code">$__tool_directory__/hmgm_main.py Segmentation $__root_dir__ $input_segmentation $output_segmentation $task_info '$context_json'</command>
+  <command detect_errors="exit_code">$__tool_directory__/hmgm_main.py Segmentation $__root_dir__ $input_segmentation $amp_segmentation $task_info '$context_json'</command>
   <inputs>
-    <param name="input_segmentation" type="data" format="json" label="Input Segmentation JSON file" help="JSON file for the Segmentation file to be corrected "/>
+    <param name="input_segmentation" type="data" format="json" label="Input AMP Segmentation JSON file" help="JSON file for the Segmentation file to be corrected "/>
     <param name="context_json" type="text" label="Human MGM Task Context" help="JSON string containing context information needed for creating Human MGM task">
 		<sanitizer sanitize="false">
     	</sanitizer>
 	</param>
   </inputs>
   <outputs>
-    <data  name="output_segmentation" format="json" />
+    <data  name="amp_segmentation" format="json" />
     <data  name="task_info" format="json" />
   </outputs>
   <tests>

--- a/tools/hmgm/hmgm_transcript.xml
+++ b/tools/hmgm/hmgm_transcript.xml
@@ -1,22 +1,22 @@
 <tool id="hmgm_transcript" name="HMGM Transcript Correction" version="1.0.2">
   <description>Manual transcript correction by a human</description>
   <command detect_errors="exit_code">
-    $__tool_directory__/../amp_json_schema/amp_stt_to_draftjs.py $input_transcript $draftjs_transcript;
-    $__tool_directory__/hmgm_main.py Transcript $__root_dir__ $draftjs_transcript $output_transcript $task_info '$context_json';
-    $__tool_directory__/../amp_json_schema/bbcEditor_to_schema.py $output_transcript $std_amp_output $draftjs_transcript
+    $__tool_directory__/../amp_json_schema/amp_stt_to_draftjs.py $input_transcript $original_draftjs_transcript;
+    $__tool_directory__/hmgm_main.py Transcript $__root_dir__ $original_draftjs_transcript $corrected_draftjs_transcript $task_info '$context_json';
+    $__tool_directory__/../amp_json_schema/bbcEditor_to_schema.py $corrected_draftjs_transcript $amp_speech_to_text $draftjs_transcript
   </command>
   <inputs>
-    <param name="input_transcript" type="data" format="json" label="Input Transcript JSON file" help="JSON file for the transcript to be corrected "/>
+    <param name="input_transcript" type="data" format="json" label="Input AMP Speech to Text JSON file" help="JSON file for the transcript to be corrected "/>
     <param name="context_json" type="text" label="Human MGM Task Context" help="JSON string containing context information needed for creating Human MGM task">
     	<sanitizer sanitize="false">
     	</sanitizer>
 	</param>
   </inputs>
   <outputs>
-    <data  name="draftjs_transcript" format="json" />
-    <data  name="output_transcript" format="json" />
+    <data  name="original_draftjs_transcript" format="json" />
+    <data  name="corrected_draftjs_transcript" format="json" />
     <data  name="task_info" format="json" />
-    <data  name="std_amp_output" format="json" />
+    <data  name="amp_speech_to_text" format="json" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/ina_speech_segmenter.xml
+++ b/tools/ina_speech_segmenter/ina_speech_segmenter.xml
@@ -2,13 +2,13 @@
   <description>Create speech segmentations containing type, gender, start offset, and end offset</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/ina_speech_segmenter_wrapper.py $input $json_out</command>
+  <command detect_errors="exit_code">$__tool_directory__/ina_speech_segmenter_wrapper.py $input $amp_segmentation</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From dataset" help="An audio file"/>
   </inputs>
   <outputs>
-    <data format="segments" name="json_out" />
+    <data format="segments" name="amp_segmentation" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/remove_silence_music.xml
+++ b/tools/ina_speech_segmenter/remove_silence_music.xml
@@ -3,15 +3,15 @@
     <requirements>
     </requirements>
   <command detect_errors="exit_code">
-  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json music $binary_out $kept_segments_json</command>
+  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json music $segmented_audio_file $kept_segments</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
     <param name="input_segmentation_json" type="data" format="segments" label="From segmentation" help="Segmentation json file"/>
   </inputs>
   <outputs>
-    <data format="audio" name="binary_out" />
-    <data format="json" name="kept_segments_json" />
+    <data format="audio" name="segmented_audio_file" />
+    <data format="json" name="kept_segments" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/remove_silence_music.xml
+++ b/tools/ina_speech_segmenter/remove_silence_music.xml
@@ -3,7 +3,7 @@
     <requirements>
     </requirements>
   <command detect_errors="exit_code">
-  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json music $segmented_audio_file $kept_segments</command>
+  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json music $segmented_audio_file $amp_kept_segments</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
@@ -11,7 +11,7 @@
   </inputs>
   <outputs>
     <data format="audio" name="segmented_audio_file" />
-    <data format="json" name="kept_segments" />
+    <data format="json" name="amp_kept_segments" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/remove_silence_speech.xml
+++ b/tools/ina_speech_segmenter/remove_silence_speech.xml
@@ -3,15 +3,15 @@
     <requirements>
     </requirements>
   <command detect_errors="exit_code">
-  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json speech $binary_out $kept_segments_json</command>
+  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json speech $segmented_audio_file $kept_segments</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
     <param name="input_segmentation_json" type="data" format="segments" label="From segmentation" help="Segmentation json file"/>
   </inputs>
   <outputs>
-    <data format="audio" name="binary_out" />
-    <data format="json" name="kept_segments_json" />
+    <data format="audio" name="segmented_audio_file" />
+    <data format="json" name="kept_segments" />
   </outputs>
   <tests>
   </tests>

--- a/tools/ina_speech_segmenter/remove_silence_speech.xml
+++ b/tools/ina_speech_segmenter/remove_silence_speech.xml
@@ -3,7 +3,7 @@
     <requirements>
     </requirements>
   <command detect_errors="exit_code">
-  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json speech $segmented_audio_file $kept_segments</command>
+  $__tool_directory__/remove_silence_music_speech.py $input $input_segmentation_json speech $segmented_audio_file $amp_kept_segments</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From audio file" help="An audio file"/>
@@ -11,7 +11,7 @@
   </inputs>
   <outputs>
     <data format="audio" name="segmented_audio_file" />
-    <data format="json" name="kept_segments" />
+    <data format="json" name="amp_kept_segments" />
   </outputs>
   <tests>
   </tests>

--- a/tools/kaldi/kaldi_local.xml
+++ b/tools/kaldi/kaldi_local.xml
@@ -3,17 +3,17 @@
     <requirements>
         <requirement type="package" version="8.30">coreutils</requirement>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/kaldi_local.py $input $output_file $text_out;
-                                    $__tool_directory__/../amp_json_schema/kaldi_local_to_schema.py $input $output_file $text_out $output_stt_json
+  <command detect_errors="exit_code">$__tool_directory__/kaldi_local.py $input $kaldi_transcript_json $kaldi_transcript_text;
+                                    $__tool_directory__/../amp_json_schema/kaldi_local_to_schema.py $input $kaldi_transcript_json $kaldi_transcript_text $amp_speech_to_text
   </command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="audio" label="From dataset" help="An audio file"/>
   </inputs>
   <outputs>
-    <data format="json" name="output_file" />
-    <data format="txt" name="text_out" />
-    <data format="json" name="output_stt_json" />
+    <data format="json" name="kaldi_transcript_json" />
+    <data format="txt" name="kaldi_transcript_text" />
+    <data format="json" name="amp_speech_to_text" />
   </outputs>
   <tests>
   </tests>

--- a/tools/media/extract_audio.xml
+++ b/tools/media/extract_audio.xml
@@ -3,7 +3,7 @@
     <requirements>
         <requirement type="package" version="8.30">coreutils</requirement>
     </requirements>
-  <command>ffmpeg -y -hide_banner -nostats -loglevel panic -i $input -ar $rate -ac $channels -c:a $samplesize -f wav $out_file1</command>
+  <command>ffmpeg -y -hide_banner -nostats -loglevel panic -i $input -ar $rate -ac $channels -c:a $samplesize -f wav $audio_file</command>
   <inputs>
     <param name="input" type="data" format="binary" label="From dataset" help="A video file"/>
     <param name="rate" type="select" label="Sample Rate">
@@ -24,7 +24,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="audio" name="out_file1" />
+    <data format="audio" name="audio_file" />
   </outputs>
   <tests>
   </tests>

--- a/tools/silence_remove/extract_silence.xml
+++ b/tools/silence_remove/extract_silence.xml
@@ -3,13 +3,13 @@
     <requirements>
         <requirement type="package" version="8.30">coreutils</requirement>
     </requirements>
-  <command>ffmpeg -y -hide_banner -nostats -loglevel panic -i $input -af "areverse,silenceremove=start_periods=1:start_duration=1:start_threshold=-60dB:detection=peak,aformat=s32,areverse" -f wav $out_file1</command>
+  <command>ffmpeg -y -hide_banner -nostats -loglevel panic -i $input -af "areverse,silenceremove=start_periods=1:start_duration=1:start_threshold=-60dB:detection=peak,aformat=s32,areverse" -f wav $audio_file</command>
   <inputs>
     <param name="input" type="data" format="binary" label="From dataset" help="An audio file"/>
     <param name="start_threshold" type="integer" value="-60" label="Silence threshold" help="A threshold decibel value for silence"/> 
   </inputs>
   <outputs>
-    <data format="audio" name="out_file1" />
+    <data format="audio" name="audio_file" />
   </outputs>
   <tests>
   </tests>

--- a/tools/spacy/spacy.xml
+++ b/tools/spacy/spacy.xml
@@ -2,7 +2,7 @@
   <description>Named entity extraction with spaCy</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code">$__tool_directory__/spacy_wrapper.py $input $json_out $ignore_categories_csv</command>
+  <command detect_errors="exit_code">$__tool_directory__/spacy_wrapper.py $input $amp_entity_extraction $ignore_categories_csv</command>
    <inputs>
    <!-- should be wave data type -->
     <param name="input" type="data" format="txt" label="From transcript" help="An transcript file"/>
@@ -12,7 +12,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="json" name="json_out" />
+    <data format="json" name="amp_entity_extraction" />
   </outputs>
   <tests>
   </tests>

--- a/tools/video_tools/azure_video_indexer.xml
+++ b/tools/video_tools/azure_video_indexer.xml
@@ -2,7 +2,7 @@
   <description>OCR Using Azure Video Indexer</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code"> $__tool_directory__/azure_video_indexer_wrapper.py $input_file $accountId $apiKey $location $ocr_json_output $ocr_json_output_long $amp_ocr_json_output</command>
+  <command detect_errors="exit_code"> $__tool_directory__/azure_video_indexer_wrapper.py $input_file $accountId $apiKey $location $azure_ocr $azure_ocr_long $amp_ocr</command>
   <inputs>
 	<param name="input_file" type="data" format="video" label="Video File" help="A video file input for OCR"/>
 	<param name="accountId" type="text" label="Azure Account ID" help="Azure Account ID"/>
@@ -14,9 +14,9 @@
     </param>
   </inputs>
   <outputs>
-    <data format="json" name="ocr_json_output" />
-    <data format="json" name="ocr_json_output_long" />
-    <data format="json" name="amp_ocr_json_output" />
+    <data format="json" name="azure_ocr" />
+    <data format="json" name="azure_ocr_long" />
+    <data format="json" name="amp_ocr" />
   </outputs>
   <tests>
   </tests>

--- a/tools/video_tools/tesseract.xml
+++ b/tools/video_tools/tesseract.xml
@@ -2,14 +2,14 @@
   <description>Runs OCR on frames in a video</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code"> $__tool_directory__/run-tesseract.py $input $ocr_json_output</command>
+  <command detect_errors="exit_code"> $__tool_directory__/run-tesseract.py $input $amp_ocr</command>
   <inputs>
 	<param name="input" type="data" format="video" label="Video File" help="A video file input for OCR"/>
 	<!--<param name="start" type="integer" value="0" label="Start time frame in seconds" help="A starting time frame on the input video"/>
 	<param name="duration" type="integer" value="0" label="Duration of video in seconds" help="Duration of the video to passed through OCR"/> -->
   </inputs>
   <outputs>
-    <data format="json" name="ocr_json_output" />
+    <data format="json" name="amp_ocr" />
   </outputs>
   <tests>
   </tests>

--- a/tools/vtt_generator/jsonToVtt_adapter.xml
+++ b/tools/vtt_generator/jsonToVtt_adapter.xml
@@ -2,13 +2,13 @@
   <description>Runs JSON transcripts</description>
     <requirements>
     </requirements>
-  <command detect_errors="exit_code"> $__tool_directory__/jsonToVtt.py $input_seg $input_stt $vtt_output_file</command>
+  <command detect_errors="exit_code"> $__tool_directory__/jsonToVtt.py $input_seg $input_stt $amp_vtt</command>
   <inputs>
 	<param name="input_seg" type="data" format="json" optional = "true" label="Speaker Diarization JSON" help="A JSON transcript input with speaker diarizationto info be added to VTT"/>
   <param name="input_stt" type="data" format="json" label="STT JSON" help="A JSON transcript input with STT info to be added to VTT"/>
   </inputs>
   <outputs>
-    <data format="data" name="vtt_output_file" />
+    <data format="data" name="amp_vtt" />
   </outputs>
   <tests>
   </tests>


### PR DESCRIPTION
Renaming output variable following the following pattern:
For standard output variables:
{source}_{format}_{optional description}

For HMGM intermediate files:
{status}_{format}

source = {aws_transcribe, azure, amp}
format = {speech_to_text, entity_extraction, segmentation, kept_segments, iif, ocr, vtt, draftjs}
optional description = {text, json} only where distinction is needed
status = {original, corrected}