### PR TITLE
AMP-893:

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -16,6 +16,8 @@
     <datatype extension="shot" type="galaxy.datatypes.text:Shot" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="face" type="galaxy.datatypes.text:Face" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="vtt" type="galaxy.datatypes.text:Vtt" mimetype="text/vtt" subclass="true" display_in_upload="true"/>
+	<!-- below segments data type is deprecated, keep it for existing legacy datasets of this type -->
+    <datatype extension="segments" type="galaxy.datatypes.text:Segments" subclass="true" display_in_upload="true" />
     <!-- END AMP Data Type Extension -->
 
     <datatype extension="ab1" type="galaxy.datatypes.binary:Ab1" mimetype="application/octet-stream" display_in_upload="true" description="A binary sequence file in 'ab1' format with a '.ab1' file extension.  You must manually select this 'File Format' when uploading the file." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Ab1"/>

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -111,6 +111,16 @@ class Json(Text):
 ######################
 
 @build_sniff_from_prefix
+class Segments(Json):
+    file_ext = "segments"
+    label = "AMP Segments JSON (depreated, use segnment instead)"
+
+    def sniff_prefix(self, file_prefix):
+        # this sniffer should not be called and it's not included as one of the sniffers in datatypes config;
+        # just in case it's called, it always returns false so no new dataset will be associated with this type 
+        return false
+       
+@build_sniff_from_prefix
 class Segment(Json):
     file_ext = "segment"
     label = "AMP Segment JSON"

--- a/tools/amp_audio/extract_audio.xml
+++ b/tools/amp_audio/extract_audio.xml
@@ -1,4 +1,4 @@
-<tool id="extract_audio" name="Extract Audio" version="1.0.2">
+<tool id="extract_audio" name="Extract Audio" version="1.0.0">
   <description>Extract audio from audio/video file</description>
   <requirements>
     <requirement type="package" version="8.30">coreutils</requirement>

--- a/tools/amp_audio/remove_trailing_silence.xml
+++ b/tools/amp_audio/remove_trailing_silence.xml
@@ -1,4 +1,4 @@
-<tool id="remove_trailing_silence" name="Remove Trailing Silence" version="1.0.2">
+<tool id="remove_trailing_silence" name="Remove Trailing Silence" version="1.0.0">
   <description>Remove trailing silence from audio file</description>
   <requirements>
     <requirement type="package" version="8.30">coreutils</requirement>

--- a/tools/amp_hmgm/hmgm_sample.xml
+++ b/tools/amp_hmgm/hmgm_sample.xml
@@ -1,4 +1,4 @@
-<tool id="hmgm_sample" name="Sample HMGM" version="1.0.2">
+<tool id="hmgm_sample" name="Sample HMGM" version="1.0.0">
   <description>Sample Human HMGM</description>
   <requirements>
 	<requirement type="package" version="3.8">python</requirement>

--- a/tools/amp_hmgm/hmgm_transcript.xml
+++ b/tools/amp_hmgm/hmgm_transcript.xml
@@ -1,4 +1,4 @@
-<tool id="hmgm_transcript" name="HMGM Transcript Correction" version="1.0.2">
+<tool id="hmgm_transcript" name="HMGM Transcript Correction" version="1.0.0">
   <description>Manual transcript correction by a human</description>
   <requirements>
 	<requirement type="package" version="3.8">python</requirement>

--- a/tools/amp_stt/aws_transcribe.xml
+++ b/tools/amp_stt/aws_transcribe.xml
@@ -1,4 +1,4 @@
-<tool id="aws_transcribe_stt" name="AWS Transcribe Speech to Text" version="1.0.2">
+<tool id="aws_transcribe_stt" name="AWS Transcribe Speech to Text" version="1.0.0">
   <description>Transcribe speech to text via AWS Transcribe</description>
   <requirements>
 	<requirement type="package" version="8.30">coreutils</requirement>

--- a/tools/amp_stt/kaldi.xml
+++ b/tools/amp_stt/kaldi.xml
@@ -1,4 +1,4 @@
-<tool id="kaldi_stt" name="Kaldi Speech to Text" version="1.0.2">
+<tool id="kaldi_stt" name="Kaldi Speech to Text" version="1.0.0">
   <description>Local Kaldi Speech-to-Text transcription</description>
   <requirements>
     <requirement type="package" version="3.8">python</requirement>


### PR DESCRIPTION
- add data type segments as deprecated, for existing legacy datasets of
this type
- change all amp tool versions to 1.0.0 to be consistent