### PR TITLE
AMP_1134: Fix build of shared object on bamboo

### DIFF
--- a/metrics/Makefile
+++ b/metrics/Makefile
@@ -2,7 +2,11 @@ all: system_metrics system_metrics.so
 
 
 system_metrics.so: system_metrics.c
-	gcc -shared -fPIC -o $@ $^
+	gcc -std=gnu99 -shared -fPIC -o $@ $^
 
 system_metrics: system_metrics.c
-	gcc -o $@ -DINTERACTIVE $^
+	gcc -std=gnu99 -o $@ -DINTERACTIVE $^
+
+
+clean:
+	rm system_metrics system_metrics.so


### PR DESCRIPTION
When building via bamboo the shared library fails to build.  Forcing gcc to use the gnu99 standard (vs some older ansi C) allows it to build correctly.
