### PR TITLE
Amp 1134 - bugfix:  ignore metrics build failure

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -58,8 +58,8 @@ fi
 mkdir logs
 pushd metrics
 make || (
-    echo "Cannot build the uwsg system_metrics.so file"
-    exit 1
+    echo "NOTICE: Cannot build the uwsg system_metrics.so file"
+    echo "        API metrics will not be collected"
 )
 popd
 


### PR DESCRIPTION
This will ignore the API metrics module build failure and galaxy should start up anyway.
