### PR TITLE
AMP-1211: remove space in admin_users list, as the new galaxy doesn't

### DIFF
--- a/config/galaxy.yml
+++ b/config/galaxy.yml
@@ -159,7 +159,7 @@ galaxy:
   # groups, roles, libraries, and more.  For more information, see:
   # https://galaxyproject.org/admin/
   # AMP admin users
-  admin_users: amppd@iu.edu, amppd-ci@iu.edu
+  admin_users: amppd@iu.edu,amppd-ci@iu.edu
       
   # AMP Performance Logging configuration
   logging:


### PR DESCRIPTION
accept it (users after space are ignored).