### PR TITLE
fix a typo where it says "cannot start tomcat"

### DIFF
--- a/amp_hook_start.py
+++ b/amp_hook_start.py
@@ -19,7 +19,7 @@ def main():
     try:
         subprocess.run([f"{os.environ['AMP_ROOT']}/galaxy/run.sh", "start"], check=True)
     except Exception as e:
-        logging.error(f"Cannot start tomcat: {e}")
+        logging.error(f"Cannot start galaxy: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix typo in the start script during failure that indicates that it's tomcat that's failing to start when it's really galaxy.